### PR TITLE
Move `ref` keyword for function parameters

### DIFF
--- a/crates/shad_parser/src/item/function.rs
+++ b/crates/shad_parser/src/item/function.rs
@@ -125,9 +125,9 @@ pub struct AstFnParam {
 
 impl AstFnParam {
     fn parse(lexer: &mut Lexer<'_>) -> Result<Self, SyntaxError> {
-        let ref_span = parse_token_option(lexer, TokenType::Ref)?.map(|ref_| ref_.span);
         let name = AstIdent::parse(lexer)?;
         parse_token(lexer, TokenType::Colon)?;
+        let ref_span = parse_token_option(lexer, TokenType::Ref)?.map(|ref_| ref_.span);
         let type_ = AstIdent::parse(lexer)?;
         Ok(Self {
             name,

--- a/examples/references.shd
+++ b/examples/references.shd
@@ -5,12 +5,12 @@ run {
     result_ref = add(add(result_ref, 5), 5);
 }
 
-fn add(ref value: i32, added: i32) -> ref i32 {
+fn add(value: ref i32, added: i32) -> ref i32 {
     value = value + added;
     return ident(value);
 }
 
-fn ident(ref value: i32) -> ref i32 {
+fn ident(value: ref i32) -> ref i32 {
     ref val = value;
     return val;
 }

--- a/tests/cases_invalid/code/fn_recursive/main.shd
+++ b/tests/cases_invalid/code/fn_recursive/main.shd
@@ -18,7 +18,7 @@ fn inner_recursive() {
     inner_recursive();
 }
 
-fn inner_returned_recursive(ref a: i32) -> i32 {
+fn inner_returned_recursive(a: ref i32) -> i32 {
     return inner_returned_recursive(a);
 }
 

--- a/tests/cases_invalid/expected/fn_recursive
+++ b/tests/cases_invalid/expected/fn_recursive
@@ -33,7 +33,7 @@ error: function `inner_recursive()` defined recursively
 error: function `inner_returned_recursive(i32)` defined recursively
   --> ./cases_invalid/code/fn_recursive/main.shd:21:4
    |
-21 | fn inner_returned_recursive(ref a: i32) -> i32 {
+21 | fn inner_returned_recursive(a: ref i32) -> i32 {
    |    ^^^^^^^^^^^^^^^^^^^^^^^^ recursive function `inner_returned_recursive(i32)` defined here
 22 |     return inner_returned_recursive(a);
    |            --------------------------- info: `inner_returned_recursive(i32)` function called in `inner_returned_recursive(i32)` function

--- a/tests/cases_valid/code/fn_call/main.shd
+++ b/tests/cases_valid/code/fn_call/main.shd
@@ -48,7 +48,7 @@ run {
     inlined(0);
 }
 
-fn inlined(ref param: i32) {
+fn inlined(param: ref i32) {
     sum1 = __add__(left: 1., right: 2.);
     sum3 = __add__(left: 1., 2.);
     sum2 = __add__(1., right: 2.);

--- a/tests/cases_valid/code/fn_call_field/main.shd
+++ b/tests/cases_valid/code/fn_call_field/main.shd
@@ -29,6 +29,6 @@ fn child(value: Level1) -> Level2 {
     return value.child;
 }
 
-fn child_ref(ref value: Level1) -> ref Level2 {
+fn child_ref(value: ref Level1) -> ref Level2 {
     return value.child;
 }

--- a/tests/cases_valid/code/ref_fn_param/main.shd
+++ b/tests/cases_valid/code/ref_fn_param/main.shd
@@ -34,18 +34,18 @@ run {
     );
 }
 
-fn without_return_value(ref ref_: i32, copied: i32) {
+fn without_return_value(ref_: ref i32, copied: i32) {
     ref_ = ref_ + copied - 1 + 1;
 }
 
-fn with_return_value(ref ref_: i32, copied: i32) -> i32 {
+fn with_return_value(ref_: ref i32, copied: i32) -> i32 {
     call_count = call_count + 1;
     not_inlined_fn();
     without_return_value(ref_, copied);
     return ref_;
 }
 
-fn with_return_inlined_value(ref ref_: i32, copied: i32) -> i32 {
+fn with_return_inlined_value(ref_: ref i32, copied: i32) -> i32 {
     ref_ = ref_ + copied;
     return with_return_value(ref_, copied);
 }

--- a/tests/cases_valid/code/ref_fn_returned/main.shd
+++ b/tests/cases_valid/code/ref_fn_returned/main.shd
@@ -15,7 +15,7 @@ run {
     ref_left_value(10);
 }
 
-fn add(ref value: i32, added: i32) -> ref i32 {
+fn add(value: ref i32, added: i32) -> ref i32 {
     value = value + added;
     identity(value) = value;
     return identity(value);
@@ -26,7 +26,7 @@ fn add_copy(value: i32, added: i32) -> ref i32 {
     return identity(value);
 }
 
-fn identity(ref value: i32) -> ref i32 {
+fn identity(value: ref i32) -> ref i32 {
     return value;
 }
 


### PR DESCRIPTION
Part of #54 