### PR TITLE
Handle min `ì32` literal value in `const` context

### DIFF
--- a/crates/shad_analyzer/src/checks/literals.rs
+++ b/crates/shad_analyzer/src/checks/literals.rs
@@ -43,18 +43,14 @@ impl LiteralCheck {
         } else {
             &literal.value
         };
-        let value_with_operator = if literal.is_neg {
-            format!("-{value}")
-        } else {
-            value.into()
-        };
-        T::from_str(&value_with_operator)
+        T::from_str(value)
             .is_err()
             .then(|| errors::literals::invalid_integer(literal, type_name))
     }
 
     fn int_part_digit_count(float: &str) -> usize {
         float
+            .replace('-', "")
             .find('.')
             .expect("internal error: `.` not found in `f32` literal")
     }

--- a/crates/shad_analyzer/src/transformation/constants.rs
+++ b/crates/shad_analyzer/src/transformation/constants.rs
@@ -68,7 +68,6 @@ impl VisitMut for ConstantTransform<'_> {
                     span: node.root.span().clone(),
                     value: Self::literal_str(&value),
                     type_: Self::literal_type(&value),
-                    is_neg: false,
                 });
             }
         }

--- a/crates/shad_analyzer/src/transformation/literals.rs
+++ b/crates/shad_analyzer/src/transformation/literals.rs
@@ -7,6 +7,9 @@ pub(crate) fn transform(analysis: &mut Analysis) {
             LiteralTransform.visit_statement(statement);
         }
     });
+    for constant in analysis.constants.values_mut() {
+        LiteralTransform.visit_const_item(&mut constant.ast);
+    }
 }
 
 struct LiteralTransform;

--- a/crates/shad_analyzer/src/transformation/ref_fn_inline.rs
+++ b/crates/shad_analyzer/src/transformation/ref_fn_inline.rs
@@ -82,7 +82,6 @@ impl VisitMut for RefFnInlineTransform<'_> {
                     span: node.span.clone(),
                     value: "0".to_string(),
                     type_: AstLiteralType::I32,
-                    is_neg: false,
                 }
                 .into();
             }

--- a/crates/shad_parser/src/atom.rs
+++ b/crates/shad_parser/src/atom.rs
@@ -53,8 +53,6 @@ pub struct AstLiteral {
     pub value: String,
     /// The type of the literal.
     pub type_: AstLiteralType,
-    /// Whether the literal is just after unary `-` operator.
-    pub is_neg: bool,
 }
 
 impl AstLiteral {
@@ -71,7 +69,6 @@ impl AstLiteral {
                 TokenType::True | TokenType::False => AstLiteralType::Bool,
                 _ => unreachable!("internal error: not supported literal"),
             },
-            is_neg: false,
         })
     }
 }

--- a/crates/shad_parser/src/expr.rs
+++ b/crates/shad_parser/src/expr.rs
@@ -86,9 +86,7 @@ impl AstExpr {
                 expr.span = Self::span(&expr.root, &expr.fields);
                 Ok(expr)
             }
-            TokenType::Minus | TokenType::Not => {
-                Ok(AstFnCall::parse_unary_operation(lexer)?.into())
-            }
+            TokenType::Minus | TokenType::Not => AstFnCall::parse_unary_operation(lexer),
             TokenType::F32Literal
             | TokenType::U32Literal
             | TokenType::I32Literal

--- a/tests/cases_invalid/code/atom/main.shd
+++ b/tests/cases_invalid/code/atom/main.shd
@@ -1,4 +1,5 @@
 buf undefined_ident = undefined;
 buf f32_too_many_digits = 123456789012345678901234567890123456_789.;
 buf u32_too_big = 4_294_967_296u;
+buf u32_negative = -1u;
 buf i32_too_big = 2_147_483_648;

--- a/tests/cases_invalid/expected/atom
+++ b/tests/cases_invalid/expected/atom
@@ -22,9 +22,16 @@ error: `u32` literal out of range
   |                   ^^^^^^^^^^^^^^ value is outside allowed range for `u32` type
   |
 
-error: `i32` literal out of range
- --> ./cases_invalid/code/atom/main.shd:4:19
+error: could not find `__neg__(u32)` function
+ --> ./cases_invalid/code/atom/main.shd:4:20
   |
-4 | buf i32_too_big = 2_147_483_648;
+4 | buf u32_negative = -1u;
+  |                    ^^^ undefined function
+  |
+
+error: `i32` literal out of range
+ --> ./cases_invalid/code/atom/main.shd:5:19
+  |
+5 | buf i32_too_big = 2_147_483_648;
   |                   ^^^^^^^^^^^^^ value is outside allowed range for `i32` type
   |

--- a/tests/cases_valid/code/atom/main.shd
+++ b/tests/cases_valid/code/atom/main.shd
@@ -3,6 +3,7 @@ buf f32_no_frac_part = 2.;
 buf f32_many_digits = 123456700.123456789;
 buf f32_max_int_digits = 12345678901234567890123456789012345678.;
 buf f32_underscores = 1_2345______670_0_.1_234_567_89___;
+buf f32_negative = -12345678901234567890123456789012345678.;
 
 buf u32_zero = 0u;
 buf u32_underscores = 1_23______456_789___u;
@@ -18,5 +19,3 @@ buf true_val = true;
 
 buf not_yet_defined = copied_buffer;
 buf copied_buffer = i32_max_value;
-
-gpu fn __neg__(value: i32) -> i32;

--- a/tests/cases_valid/code/constant/main.shd
+++ b/tests/cases_valid/code/constant/main.shd
@@ -1,13 +1,15 @@
 const I32 = 123;
+const MIN_I32 =  -2_147_483_648;
 const U32 = 123u;
 const F32_WITHOUT_DECIMAL = 123.;
 const F32_WITH_DECIMAL = 123.4;
 const TRUE = true;
 const FALSE = false;
 const U32_COPY = U32;
-const CONST_FN_CALL = I32 + -2;
+const CONST_FN_CALL = 10 + -I32;
 
 buf i32_result = I32;
+buf min_i32_result = MIN_I32;
 buf u32_result = U32;
 buf f32_without_decimal_result = F32_WITHOUT_DECIMAL;
 buf f32_with_decimal_result = F32_WITH_DECIMAL;

--- a/tests/cases_valid/expected/atom
+++ b/tests/cases_valid/expected/atom
@@ -1,6 +1,7 @@
 main.copied_buffer=2147483647
 main.f32_many_digits=123456700
 main.f32_max_int_digits=12345678000000000000000000000000000000
+main.f32_negative=-12345678000000000000000000000000000000
 main.f32_no_frac_part=2
 main.f32_underscores=123456700
 main.f32_zero=0

--- a/tests/cases_valid/expected/constant
+++ b/tests/cases_valid/expected/constant
@@ -1,9 +1,10 @@
-main.const_fn_call_result=121
+main.const_fn_call_result=-113
 main.const_ref_param_result=125
 main.f32_with_decimal_result=123.4
 main.f32_without_decimal_result=123
 main.false_result=0
 main.i32_result=123
+main.min_i32_result=-2147483648
 main.true_result=1
 main.u32_copy_result=123
 main.u32_result=123


### PR DESCRIPTION
Part of #79 